### PR TITLE
fix: correct underline class on press kit page

### DIFF
--- a/src/app/press-kit/page.tsx
+++ b/src/app/press-kit/page.tsx
@@ -42,7 +42,7 @@ export default function PressKit() {
               </a>
               , a reimagined platform for schools, but he&apos;s always
               experimenting with new ideas. He shares his thoughts on{" "}
-              <a href="https://x.com/jonba_" className="underlroine font-bold">
+              <a href="https://x.com/jonba_" className="underline font-bold">
                 X
               </a>
               , and if you want to chat, you can reach him at{" "}


### PR DESCRIPTION
## Summary
- correct the underline class on the Twitter link in the press kit

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865d3ad34748332a3197c6446100c98