### PR TITLE
fix: correct Elliott Friedrich avatar paths

### DIFF
--- a/src/components/work-showcase.tsx
+++ b/src/components/work-showcase.tsx
@@ -249,7 +249,7 @@ const works = [
       {
         name: "Elliott Friedrich",
         role: "Developer",
-        avatar: "elliott.jpg",
+        avatar: "/elliott.jpg",
         link: "https://www.linkedin.com/in/elliott-friedrich-0460962b0/",
       },
       {
@@ -321,7 +321,7 @@ const works = [
       {
         name: "Elliott Friedrich",
         role: "Designer & Developer",
-        avatar: "elliott.jpg",
+        avatar: "/elliott.jpg",
         link: "https://www.linkedin.com/in/elliott-friedrich-0460962b0/",
       },
       {


### PR DESCRIPTION
## Summary
- fix missing leading slashes for Elliott Friedrich avatar references

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6865d3b13eec833290e3ae3d89bb2863